### PR TITLE
Add mysqlm CLI for managing MySQL on Amazon Linux 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,160 @@
-# MySQL-Manager
+# mysqlm – Oracle MySQL Manager for Amazon Linux 2
+
+`mysqlm` is an interactive, production-ready Python CLI for managing Oracle MySQL Community Server on Amazon Linux 2. It streamlines installing specific minor releases, provisioning isolated instances, tuning configuration, performing backups, and executing upgrades – all while enforcing safe defaults and idempotent operations.
+
+## Key Capabilities
+
+- Discover and install the latest patch for a requested major.minor (5.7 or 8.0) via the official Oracle Yum repository, with fallbacks and conflict detection.
+- Manage multiple MySQL instances on a single EC2 host with dedicated configuration, data, runtime, and logging directories.
+- Generate secure root passwords, bootstrap new datadirs, and optionally bring up instances through dedicated systemd units (`mysqld-<name>.service`).
+- Interactively adjust configuration parameters with validation and optional live-value inspection.
+- Run logical backups/restores, pre-upgrade health checks, and in-place upgrades with optional safety backups.
+- Provide rich logging to both console and rotating log files, plus detailed prompts and confirmations for destructive actions.
+
+## Prerequisites
+
+1. **Operating system**: Amazon Linux 2 with systemd.
+2. **Python**: Version 3.9+ available (use the Amazon Linux `python3` package or newer from EPEL).
+3. **System access**: sudo/root privileges – the CLI will abort actions that require elevated permissions.
+4. **Packages/tools**:
+   - `sudo yum install -y yum-utils` (provides `yum-config-manager` for repository management).
+   - Oracle MySQL Community Server RPMs accessible via the internet or previously cached locally.
+   - Ensure no MariaDB packages are installed (`rpm -qa | grep -i mariadb`); the CLI aborts when conflicts are detected.
+5. **Python dependencies**: Installed automatically via `pip`, but outbound internet access is required.
+
+## Installation
+
+```bash
+# Clone the repository
+sudo yum install -y git python3-pip
+git clone <repository-url>
+cd MySQL-Manager
+
+# (Recommended) create a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install the CLI
+pip install -e .
+
+# The `mysqlm` command is now available (activate the venv or add to PATH)
+mysqlm --help
+```
+
+> **Tip:** when running the CLI with sudo, activate the virtual environment inside the sudo session (`sudo -E`) or install globally for system use.
+
+## Directory Layout & State Files
+
+| Path | Purpose |
+|------|---------|
+| `/etc/mysqlm/config.yaml` | Global mysqlm settings (created on first run; currently reserved for future global defaults). |
+| `/etc/mysqlm/instances/<name>.yaml` | Registry entries describing each managed instance. |
+| `/var/lib/mysql-instances/<name>` | Dedicated datadir for instance `<name>`. |
+| `/etc/mysql-instances/<name>/my.cnf` | Instance-specific configuration file. |
+| `/etc/mysql-instances/<name>/root-password.txt` | Secure root password generated during initialization (`chmod 600`). |
+| `/var/log/mysql-<name>/` | Error and slow query logs for the instance. |
+| `/var/run/mysql-<name>/` | Socket and PID files. |
+| `/var/backups/mysql/<name>/` | Logical backup archive root. |
+| `/var/log/mysqlm/mysqlm.log` | Rotating mysqlm operational log (5×5 MB). |
+
+### Instance Registry Schema
+
+Each `/etc/mysqlm/instances/<name>.yaml` file stores:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Instance identifier (e.g., `prod01`). |
+| `port` | TCP listener port. |
+| `socket` | UNIX socket path. |
+| `datadir` | Data directory. |
+| `config_path` | `my.cnf` location. |
+| `log_dir` | Directory containing logs (`error_log`, `slow_log`). |
+| `error_log` / `slow_log` | Specific log file paths. |
+| `pid_file` | PID file path used by systemd. |
+| `runtime_dir` | Directory that houses sockets/PID files. |
+| `backup_dir` | Root backup directory for the instance. |
+| `mysql_version` | Installed MySQL version (latest detected patch). |
+| `created_at` / `last_modified` | UTC ISO timestamps for lifecycle tracking. |
+| `systemd_unit` | The dedicated unit name (`mysqld-<name>.service`). |
+| `root_password_path` | File storing the generated root password. |
+| `root_password_set` | Whether mysqlm successfully applied the password post-initialization. |
+
+## Usage Overview
+
+Run `mysqlm --help` for the top-level help and `mysqlm <command> --help` for per-command options.
+
+```bash
+# Discover available Oracle MySQL builds
+sudo mysqlm list-available
+
+# Install the latest 8.0.x patch (prompts for confirmation)
+sudo mysqlm install --version 8.0
+
+# Provision an instance named prod01 on port 3306
+sudo mysqlm init-instance --name prod01 --port 3306
+
+# View registered instances
+mysqlm list-instances
+
+# Start/stop via systemd wrappers
+sudo mysqlm start prod01
+sudo mysqlm status prod01
+sudo mysqlm stop prod01
+
+# Tune configuration safely
+sudo mysqlm set-parameter prod01 innodb_buffer_pool_size 2G
+sudo mysqlm show-parameters prod01 --live
+
+# Back up and restore
+sudo mysqlm backup prod01 --output /var/backups/mysql/prod01
+sudo mysqlm restore prod01 /var/backups/mysql/prod01/prod01-20240101-full.sql
+
+# Upgrade to the latest 8.0.x patch (backup by default)
+sudo mysqlm upgrade prod01 --to 8.0
+
+# Remove an instance (keep data directory if desired)
+sudo mysqlm remove-instance prod01 --keep-data
+```
+
+All destructive actions prompt for confirmation unless `--no-*` flags are specified. The CLI masks secrets in logs and never prints generated passwords.
+
+## Logging & Verbosity
+
+- Console output defaults to `INFO` level. Add `--verbose` to any command for debug-level tracing.
+- Structured logs are written to `/var/log/mysqlm/mysqlm.log` with rotation (5 files × 5 MB).
+- MySQL server logs remain in the per-instance directories under `/var/log/mysql-<name>/`.
+
+## Upgrades & Backups
+
+- `mysqlm upgrade` runs optional logical backups (`mysqldump --single-transaction`) before patching packages and executing `mysql_upgrade`.
+- Backups are stored under `/var/backups/mysql/<instance>/<timestamp>/<instance>-<timestamp>.sql` by default; pass `--output` to override.
+- `restore` streams SQL files directly into `mysql` using the stored root password; ensure target instance is stopped or prepared appropriately.
+
+## Configuration Management
+
+- `set-parameter` edits the `[mysqld]` block in the instance `my.cnf`, validating numeric/boolean/size values.
+- `show-parameters` reads configured values and can optionally query live MySQL variables (requires the instance to be running and the stored root password to be valid).
+- After changing tunables the CLI offers to restart the instance (unless `--no-restart` is provided).
+
+## Security & Safety Notes
+
+- Directories are created with restrictive permissions (typically `750` for directories, `640` for config/log files, `600` for password files). Ownership is shifted to the `mysql:mysql` account when present.
+- Root/sudo is required for package installation, datadir initialization, and systemd manipulations. Non-privileged invocations are rejected with actionable guidance.
+- mysqlm detects conflicting MariaDB packages and aborts before installation, reducing risk of accidental replacement.
+- SELinux/AppArmor denials are logged but not automatically remediated; consult `/var/log/audit/audit.log` if mysqld fails to start.
+
+## Troubleshooting
+
+- **Repository issues**: If `yum-config-manager` is missing, install `yum-utils`. Verify `/etc/yum.repos.d/mysql-community.repo` exists.
+- **Initialization failures**: Review `/var/log/mysql-<name>/mysqld.log` and `/var/log/mysqlm/mysqlm.log` for detailed errors. Ensure `/var/lib/mysql-instances/<name>` is empty before retrying.
+- **Systemd startup problems**: `sudo systemctl status mysqld-<name>` and `journalctl -u mysqld-<name>` provide extended diagnostics.
+- **Root password mismatch**: If mysqlm could not apply the generated password, use `mysql_secure_installation` or manually `ALTER USER` using the temporary password noted in the error log.
+- **Port collisions**: The CLI checks for active listeners on the selected port. Use `sudo lsof -i :PORT` to inspect conflicts.
+
+## Extensibility
+
+The project is organized into modular components (`mysql_repository`, `instance_manager`, `parameters`, `backups`, `upgrade`, etc.) to ease future enhancements such as monitoring hooks, TLS provisioning, or replication management. System interactions are centralized in `mysqlm/system.py`, simplifying auditing and testing.
+
+---
+
+Feel free to open issues or submit pull requests for additional features and improvements.

--- a/mysqlm/__init__.py
+++ b/mysqlm/__init__.py
@@ -1,0 +1,5 @@
+"""MySQL Manager package."""
+
+from .cli import app, main
+
+__all__ = ["app", "main"]

--- a/mysqlm/__main__.py
+++ b/mysqlm/__main__.py
@@ -1,0 +1,5 @@
+"""Allow python -m mysqlm."""
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/mysqlm/backups.py
+++ b/mysqlm/backups.py
@@ -1,0 +1,67 @@
+"""Backup and restore helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .logging_utils import get_logger
+from .models import InstanceConfig
+from .system import run_command
+from .utils import ensure_directory, timestamp
+
+LOGGER = get_logger(__name__)
+
+
+def _read_root_password(instance: InstanceConfig) -> str:
+    path = Path(instance.root_password_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Root password file {path} not found. Cannot perform backup/restore."
+        )
+    return path.read_text().strip()
+
+
+def perform_backup(instance: InstanceConfig, destination_dir: Optional[Path] = None) -> Path:
+    password = _read_root_password(instance)
+    stamp = timestamp()
+    target_dir = destination_dir or Path(instance.backup_dir) / stamp
+    ensure_directory(target_dir, mode=0o750)
+    outfile = target_dir / f"{instance.name}-{stamp}.sql"
+    LOGGER.info("Writing backup to %s", outfile)
+    run_command(
+        [
+            "mysqldump",
+            "--single-transaction",
+            "--routines",
+            "--events",
+            "--triggers",
+            f"--socket={instance.socket}",
+            "-uroot",
+            f"-p{password}",
+            "--all-databases",
+        ],
+        sudo=True,
+        mask_secrets=[password],
+        stdout_path=outfile,
+    )
+    LOGGER.info("Backup completed: %s", outfile)
+    return outfile
+
+
+def restore_backup(instance: InstanceConfig, backup_file: Path) -> None:
+    if not backup_file.exists():
+        raise FileNotFoundError(f"Backup file {backup_file} does not exist")
+    password = _read_root_password(instance)
+    LOGGER.info("Restoring backup from %s", backup_file)
+    run_command(
+        [
+            "mysql",
+            f"--socket={instance.socket}",
+            "-uroot",
+            f"-p{password}",
+        ],
+        sudo=True,
+        mask_secrets=[password],
+        stdin_path=backup_file,
+    )
+    LOGGER.info("Restore completed")

--- a/mysqlm/cli.py
+++ b/mysqlm/cli.py
@@ -1,0 +1,279 @@
+"""Command line interface for mysqlm."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.table import Table
+
+from . import constants
+from .backups import perform_backup, restore_backup
+from .instance_manager import InstanceManager
+from .logging_utils import configure_logging, get_logger
+from .models import InstanceConfig
+from .mysql_repository import MySQLRepositoryManager
+from .parameters import display_parameters, set_parameter, show_parameters
+from .registry import ConfigStore, InstanceRegistry
+from .system import ensure_root, run_command
+from .upgrade import UpgradeManager
+from .utils import choose, confirm, console, info_table
+
+app = typer.Typer(help="Manage Oracle MySQL Community Server on Amazon Linux 2")
+LOGGER = get_logger(__name__)
+
+
+class AppState:
+    def __init__(self) -> None:
+        self.console = console
+        self.config_store = ConfigStore()
+        self.registry = InstanceRegistry()
+        self.instance_manager = InstanceManager(self.registry)
+        self.repo_manager = MySQLRepositoryManager()
+        self.upgrade_manager = UpgradeManager(self.registry)
+
+
+def _validate_minor(version: str) -> str:
+    pattern = re.compile(r"^\d+\.\d+$")
+    if not pattern.match(version):
+        raise typer.BadParameter("Version must be in <major>.<minor> format, e.g. 8.0")
+    return version
+
+
+@app.callback()
+def main(ctx: typer.Context, verbose: bool = typer.Option(False, "--verbose", help="Enable debug logging")) -> None:
+    configure_logging(verbose)
+    ctx.obj = AppState()
+
+
+@app.command("list-available")
+def list_available(ctx: typer.Context) -> None:
+    state: AppState = ctx.obj
+    versions = state.repo_manager.list_available_versions()
+    table = Table(title="Available MySQL Versions")
+    table.add_column("Version")
+    table.add_column("Release")
+    for version in versions:
+        table.add_row(version.version, version.release)
+    state.console.print(table)
+
+
+@app.command()
+def install(ctx: typer.Context, version: str = typer.Option(..., "--version", callback=_validate_minor, help="MySQL major.minor version to install")) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    if version not in constants.SUPPORTED_MINORS:
+        if not confirm(
+            f"Version {version} is not officially listed. Continue attempting installation?",
+            default=False,
+        ):
+            raise typer.Abort()
+    if not confirm(f"Proceed to install MySQL {version}?", default=True):
+        typer.echo("Aborted")
+        raise typer.Abort()
+    resolved = state.repo_manager.install_version(version)
+    state.console.print(f"Installed MySQL {resolved.version} ({resolved.release})")
+
+
+def _load_instance(ctx: typer.Context, name: str) -> InstanceConfig:
+    state: AppState = ctx.obj
+    try:
+        return state.registry.load(name)
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(str(exc))
+
+
+def _detect_installed_version() -> Optional[str]:
+    try:
+        result = run_command(["mysqld", "--version"])
+        match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
+        if match:
+            return match.group(1)
+    except Exception as exc:  # pragma: no cover
+        LOGGER.warning("Failed to detect installed MySQL version: %s", exc)
+    return None
+
+
+@app.command("init-instance")
+def init_instance(
+    ctx: typer.Context,
+    name: Optional[str] = typer.Option(None, "--name", help="Instance name"),
+    port: Optional[int] = typer.Option(None, "--port", help="Listen port"),
+    mysql_minor: Optional[str] = typer.Option(None, "--mysql-version", help="MySQL major.minor version"),
+) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    if not name:
+        name = typer.prompt("Instance name", type=str)
+    if state.registry.exists(name):
+        raise typer.BadParameter(f"Instance '{name}' already exists")
+    if port is None:
+        port = state.instance_manager.suggest_port()
+        if not confirm(f"Use port {port}?", default=True):
+            port = typer.prompt("Port", type=int)
+    if mysql_minor is None:
+        mysql_minor = choose("Select MySQL minor", constants.SUPPORTED_MINORS) or "8.0"
+    else:
+        _validate_minor(mysql_minor)
+
+    detected_version = _detect_installed_version()
+    if detected_version:
+        LOGGER.info("Detected MySQL binary version %s", detected_version)
+
+    instance = state.instance_manager.create_instance(name, port, detected_version or mysql_minor)
+    state.console.print(f"Instance {name} created")
+    info_table(
+        f"Instance {name}",
+        [
+            ("Name", instance.name),
+            ("Port", str(instance.port)),
+            ("Socket", instance.socket),
+            ("Datadir", instance.datadir),
+            ("Config", instance.config_path),
+            ("Logs", instance.log_dir),
+            ("Root password", instance.root_password_path),
+            ("Systemd unit", instance.systemd_unit),
+        ],
+    )
+    if confirm("Enable and start the systemd service now?", default=True):
+        state.instance_manager.start_instance(name)
+        state.console.print("Instance started via systemd")
+
+
+@app.command()
+def list_instances(ctx: typer.Context) -> None:
+    state: AppState = ctx.obj
+    table = Table(title="Registered MySQL Instances")
+    table.add_column("Name", style="bold")
+    table.add_column("Port")
+    table.add_column("Socket")
+    table.add_column("Datadir")
+    table.add_column("Version")
+    table.add_column("Systemd Unit")
+    for instance in state.registry.list_instances():
+        table.add_row(
+            instance.name,
+            str(instance.port),
+            instance.socket,
+            instance.datadir,
+            instance.mysql_version or "?",
+            instance.systemd_unit,
+        )
+    state.console.print(table)
+
+
+@app.command()
+def start(ctx: typer.Context, name: str = typer.Argument(...)) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    state.instance_manager.start_instance(name)
+    state.console.print(f"Instance {name} started")
+
+
+@app.command()
+def stop(ctx: typer.Context, name: str = typer.Argument(...)) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    state.instance_manager.stop_instance(name)
+    state.console.print(f"Instance {name} stopped")
+
+
+@app.command()
+def restart(ctx: typer.Context, name: str = typer.Argument(...)) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    state.instance_manager.restart_instance(name)
+    state.console.print(f"Instance {name} restarted")
+
+
+@app.command()
+def status(ctx: typer.Context, name: str = typer.Argument(...)) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    output = state.instance_manager.status_instance(name)
+    state.console.print(output)
+
+
+@app.command("remove-instance")
+def remove_instance(
+    ctx: typer.Context,
+    name: str = typer.Argument(...),
+    keep_data: bool = typer.Option(False, "--keep-data", help="Preserve data directory"),
+) -> None:
+    ensure_root()
+    if not confirm(f"Really remove instance {name}?", default=False):
+        raise typer.Abort()
+    state: AppState = ctx.obj
+    state.instance_manager.remove_instance(name, keep_data=keep_data)
+    state.console.print(f"Instance {name} removed")
+
+
+@app.command("set-parameter")
+def set_parameter_cmd(
+    ctx: typer.Context,
+    name: str = typer.Argument(...),
+    parameter: str = typer.Argument(...),
+    value: str = typer.Argument(...),
+    no_restart: bool = typer.Option(False, "--no-restart", help="Do not restart automatically"),
+) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    instance = _load_instance(ctx, name)
+    set_parameter(instance, parameter, value)
+    state.registry.save(instance)
+    if not no_restart and confirm("Restart instance to apply changes?", default=True):
+        state.instance_manager.restart_instance(name)
+        state.console.print("Instance restarted")
+
+
+@app.command("show-parameters")
+def show_parameters_cmd(
+    ctx: typer.Context,
+    name: str = typer.Argument(...),
+    live: bool = typer.Option(False, "--live", help="Query live values via mysql"),
+) -> None:
+    instance = _load_instance(ctx, name)
+    configured, live_values = show_parameters(instance, live=live)
+    display_parameters(instance, configured, live_values)
+
+
+@app.command()
+def backup(ctx: typer.Context, name: str = typer.Argument(...), output: Optional[Path] = typer.Option(None, "--output", help="Backup destination directory")) -> None:
+    ensure_root()
+    instance = _load_instance(ctx, name)
+    path = perform_backup(instance, output)
+    typer.echo(f"Backup written to {path}")
+
+
+@app.command()
+def restore(ctx: typer.Context, name: str = typer.Argument(...), backup_file: Path = typer.Argument(..., exists=True, dir_okay=False)) -> None:
+    ensure_root()
+    instance = _load_instance(ctx, name)
+    if not confirm(f"Restore {backup_file} into instance {name}?", default=False):
+        raise typer.Abort()
+    restore_backup(instance, backup_file)
+    typer.echo("Restore completed")
+
+
+@app.command()
+def upgrade(
+    ctx: typer.Context,
+    name: str = typer.Argument(...),
+    to: str = typer.Option(..., "--to", callback=_validate_minor, help="Target MySQL minor version"),
+    no_backup: bool = typer.Option(False, "--no-backup", help="Skip automatic backup"),
+) -> None:
+    ensure_root()
+    state: AppState = ctx.obj
+    if not confirm(f"Upgrade instance {name} to MySQL {to}?", default=False):
+        raise typer.Abort()
+    upgraded = state.upgrade_manager.upgrade_instance(name, to, take_backup=not no_backup)
+    state.console.print(f"Instance {name} now running MySQL {upgraded.mysql_version}")
+
+
+def main() -> None:  # pragma: no cover
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/mysqlm/constants.py
+++ b/mysqlm/constants.py
@@ -1,0 +1,35 @@
+"""Project-wide constants."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+GLOBAL_CONFIG_PATHS = [
+    Path("/etc/mysqlm/config.yaml"),
+    Path("/usr/local/etc/mysqlm/config.yaml"),
+]
+
+INSTANCE_REGISTRY_DIR = Path("/etc/mysqlm/instances")
+
+DEFAULT_DATA_ROOT = Path("/var/lib/mysql-instances")
+DEFAULT_CONFIG_ROOT = Path("/etc/mysql-instances")
+DEFAULT_LOG_ROOT = Path("/var/log/mysql")
+DEFAULT_RUNTIME_ROOT = Path("/var/run")
+DEFAULT_BACKUP_ROOT = Path("/var/backups/mysql")
+DEFAULT_LOG_DIR = Path("/var/log/mysqlm")
+
+DEFAULT_SOCKET_TEMPLATE = "/var/run/mysql-{name}/mysqld.sock"
+DEFAULT_ERROR_LOG_TEMPLATE = "/var/log/mysql-{name}/mysqld.log"
+DEFAULT_SLOW_LOG_TEMPLATE = "/var/log/mysql-{name}/mysql-slow.log"
+DEFAULT_PID_TEMPLATE = "/var/run/mysql-{name}/mysqld.pid"
+DEFAULT_SYSTEMD_UNIT_TEMPLATE = "mysqld-{name}.service"
+
+SUPPORTED_MINORS = {"5.7", "8.0"}
+
+MYSQL_RELEASE_RPMS = {
+    "8.0": "https://repo.mysql.com/mysql80-community-release-el7-5.noarch.rpm",
+    "5.7": "https://repo.mysql.com/mysql57-community-release-el7-11.noarch.rpm",
+}
+
+MYSQL_PACKAGE = "mysql-community-server"
+MYSQL_CLIENT_PACKAGE = "mysql-community-client"

--- a/mysqlm/instance_manager.py
+++ b/mysqlm/instance_manager.py
@@ -1,0 +1,325 @@
+"""MySQL instance lifecycle management."""
+from __future__ import annotations
+
+import grp
+import os
+import pwd
+import secrets
+import shutil
+import socket
+import stat
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from . import constants
+from .logging_utils import get_logger
+from .models import InstanceConfig
+from .registry import InstanceRegistry
+from .system import run_command, wait_for_socket
+from .systemd import SystemdManager
+from .utils import ensure_directory
+
+LOGGER = get_logger(__name__)
+
+
+class InstanceManager:
+    """Create and manage MySQL server instances."""
+
+    def __init__(self, registry: InstanceRegistry, systemd: Optional[SystemdManager] = None) -> None:
+        self.registry = registry
+        self.systemd = systemd or SystemdManager()
+
+    # ----------------------- helpers -----------------------
+    def _generate_paths(self, name: str) -> Dict[str, Path]:
+        return {
+            "datadir": constants.DEFAULT_DATA_ROOT / name,
+            "conf_dir": constants.DEFAULT_CONFIG_ROOT / name,
+            "config_path": constants.DEFAULT_CONFIG_ROOT / name / "my.cnf",
+            "log_dir": Path(constants.DEFAULT_ERROR_LOG_TEMPLATE.format(name=name)).parent,
+            "runtime_dir": Path(constants.DEFAULT_SOCKET_TEMPLATE.format(name=name)).parent,
+            "socket": Path(constants.DEFAULT_SOCKET_TEMPLATE.format(name=name)),
+            "error_log": Path(constants.DEFAULT_ERROR_LOG_TEMPLATE.format(name=name)),
+            "slow_log": Path(constants.DEFAULT_SLOW_LOG_TEMPLATE.format(name=name)),
+            "pid_file": Path(constants.DEFAULT_PID_TEMPLATE.format(name=name)),
+            "backup_dir": constants.DEFAULT_BACKUP_ROOT / name,
+        }
+
+    def _ensure_paths(self, paths: Dict[str, Path]) -> None:
+        for key in ("datadir", "conf_dir", "log_dir", "runtime_dir", "backup_dir"):
+            ensure_directory(paths[key])
+        for file_key in ("error_log", "slow_log", "pid_file", "socket"):
+            ensure_directory(paths[file_key].parent)
+            if file_key in ("error_log", "slow_log") and not paths[file_key].exists():
+                paths[file_key].touch()
+                os.chmod(paths[file_key], 0o640)
+
+    def _set_permissions(self, paths: Dict[str, Path]) -> None:
+        try:
+            mysql_user = pwd.getpwnam("mysql")
+            mysql_group = grp.getgrnam("mysql")
+            uid = mysql_user.pw_uid
+            gid = mysql_group.gr_gid
+        except KeyError:
+            LOGGER.warning("MySQL user or group not found. Directories will remain owned by current user.")
+            uid = gid = None
+        for directory in (
+            paths["datadir"],
+            paths["log_dir"],
+            paths["runtime_dir"],
+            paths["backup_dir"],
+            paths["conf_dir"],
+        ):
+            if uid is not None:
+                shutil.chown(directory, user=uid, group=gid)
+            os.chmod(directory, 0o750)
+
+    def suggest_port(self) -> int:
+        ports = {instance.port for instance in self.registry.list_instances()}
+        candidate = 3306
+        while candidate in ports:
+            candidate += 1
+        return candidate
+
+    def _ensure_port_available(self, port: int) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                raise RuntimeError(f"Port {port} is already in use")
+
+    def _render_config(self, port: int, paths: Dict[str, Path]) -> str:
+        return f"""
+[mysqld]
+user=mysql
+datadir={paths['datadir']}
+socket={paths['socket']}
+log-error={paths['error_log']}
+slow_query_log=ON
+slow_query_log_file={paths['slow_log']}
+pid-file={paths['pid_file']}
+port={port}
+
+# Default tuning (adjust via mysqlm set-parameter)
+innodb_buffer_pool_size=1G
+max_connections=200
+sql_mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+
+[client]
+port={port}
+socket={paths['socket']}
+""".strip()
+
+    def _write_config(self, config: str, path: Path) -> None:
+        ensure_directory(path.parent)
+        path.write_text(config)
+        os.chmod(path, 0o640)
+
+    def _initialize_datadir(self, paths: Dict[str, Path]) -> None:
+        datadir = paths["datadir"]
+        if any(datadir.iterdir()):
+            LOGGER.info("Datadir %s already initialized", datadir)
+            return
+        cmd = [
+            "mysqld",
+            "--initialize",
+            f"--datadir={datadir}",
+            "--user=mysql",
+            f"--log-error={paths['error_log']}",
+        ]
+        run_command(cmd, sudo=True)
+
+    def _extract_temporary_password(self, error_log: Path) -> Optional[str]:
+        if not error_log.exists():
+            LOGGER.warning("Error log %s not found; cannot read temporary password", error_log)
+            return None
+        lines = error_log.read_text().splitlines()
+        for line in reversed(lines):
+            if "temporary password" in line.lower():
+                return line.split()[-1]
+        LOGGER.warning("Temporary password not located in %s", error_log)
+        return None
+
+    def _generate_root_password(self) -> str:
+        return secrets.token_urlsafe(24)
+
+    def _store_root_password(self, password: str, config_dir: Path) -> Path:
+        ensure_directory(config_dir)
+        path = config_dir / "root-password.txt"
+        path.write_text(password + "\n")
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        return path
+
+    def _bootstrap_root_password(
+        self,
+        instance: InstanceConfig,
+        temp_password: Optional[str],
+        new_password: str,
+    ) -> bool:
+        if not temp_password:
+            LOGGER.warning("Skipping root password bootstrap; temporary password unavailable")
+            return False
+        LOGGER.info("Starting mysqld temporarily to set persistent root password")
+        cmd = ["mysqld", f"--defaults-file={instance.config_path}", "--daemonize"]
+        run_command(cmd, sudo=True)
+        try:
+            wait_for_socket(Path(instance.socket), timeout=90)
+            sql = (
+                "ALTER USER 'root'@'localhost' IDENTIFIED BY '{pwd}'; FLUSH PRIVILEGES;"
+            ).format(pwd=new_password)
+            run_command(
+                [
+                    "mysql",
+                    f"--socket={instance.socket}",
+                    "-uroot",
+                    f"-p{temp_password}",
+                    "--connect-expired-password",
+                    "-e",
+                    sql,
+                ],
+                sudo=True,
+                mask_secrets=[temp_password, new_password],
+            )
+            LOGGER.info("Root password updated")
+            return True
+        finally:
+            run_command(
+                [
+                    "mysqladmin",
+                    f"--socket={instance.socket}",
+                    "-uroot",
+                    f"-p{new_password}",
+                    "shutdown",
+                ],
+                sudo=True,
+                mask_secrets=[new_password],
+                check=False,
+            )
+            try:
+                wait_for_socket(Path(instance.socket), timeout=30, expect_exists=False)
+            except TimeoutError:
+                LOGGER.warning("mysqld did not shut down cleanly; please check logs")
+
+    def _mysqld_path(self) -> str:
+        path = shutil.which("mysqld")
+        if not path:
+            raise FileNotFoundError("mysqld binary not found in PATH")
+        return path
+
+    def render_systemd_unit(self, instance: InstanceConfig) -> str:
+        mysqld_path = self._mysqld_path()
+        return f"""
+[Unit]
+Description=MySQL Server instance {instance.name} managed by mysqlm
+After=network.target
+
+[Service]
+Type=simple
+User=mysql
+Group=mysql
+ExecStart={mysqld_path} --defaults-file={instance.config_path}
+ExecStop=/bin/kill -TERM $MAINPID
+TimeoutSec=600
+Restart=on-failure
+LimitNOFILE=65535
+PIDFile={instance.pid_file}
+
+[Install]
+WantedBy=multi-user.target
+""".strip()
+
+    # ----------------------- public API -----------------------
+    def create_instance(
+        self,
+        name: str,
+        port: Optional[int],
+        mysql_version: Optional[str],
+    ) -> InstanceConfig:
+        if self.registry.exists(name):
+            raise ValueError(f"Instance '{name}' already exists")
+        if port is None:
+            port = self.suggest_port()
+        self._ensure_port_available(port)
+        paths = self._generate_paths(name)
+        self._ensure_paths(paths)
+        self._set_permissions(paths)
+        config_text = self._render_config(port, paths)
+        self._write_config(config_text, paths["config_path"])
+        self._initialize_datadir(paths)
+        temp_password = self._extract_temporary_password(paths["error_log"])
+        new_password = self._generate_root_password()
+        password_path = self._store_root_password(new_password, paths["conf_dir"])
+
+        now = datetime.utcnow().isoformat()
+        instance = InstanceConfig(
+            name=name,
+            port=port,
+            socket=str(paths["socket"]),
+            datadir=str(paths["datadir"]),
+            config_path=str(paths["config_path"]),
+            log_dir=str(paths["log_dir"]),
+            error_log=str(paths["error_log"]),
+            slow_log=str(paths["slow_log"]),
+            pid_file=str(paths["pid_file"]),
+            runtime_dir=str(paths["runtime_dir"]),
+            backup_dir=str(paths["backup_dir"]),
+            mysql_version=mysql_version,
+            created_at=now,
+            last_modified=now,
+            systemd_unit=constants.DEFAULT_SYSTEMD_UNIT_TEMPLATE.format(name=name),
+            root_password_path=str(password_path),
+            root_password_set=False,
+        )
+
+        if self._bootstrap_root_password(instance, temp_password, new_password):
+            instance.root_password_set = True
+        else:
+            LOGGER.warning(
+                "Root password stored at %s but may not be applied. Run mysql_secure_installation after first start.",
+                password_path,
+            )
+        self.registry.save(instance)
+        return instance
+
+    def remove_instance(self, name: str, keep_data: bool = False) -> None:
+        instance = self.registry.load(name)
+        self.systemd.stop(instance.systemd_unit)
+        self.systemd.disable(instance.systemd_unit)
+        unit_path = self.systemd.unit_path(instance.systemd_unit)
+        if unit_path.exists():
+            unit_path.unlink()
+            self.systemd.daemon_reload()
+        if not keep_data:
+            for path_str in (instance.datadir, instance.log_dir):
+                path = Path(path_str)
+                if path.exists():
+                    shutil.rmtree(path)
+        runtime_path = Path(instance.runtime_dir)
+        if runtime_path.exists():
+            shutil.rmtree(runtime_path)
+        conf_dir = Path(instance.config_path).parent
+        if conf_dir.exists():
+            shutil.rmtree(conf_dir)
+        backup_dir = Path(instance.backup_dir)
+        if backup_dir.exists() and not keep_data:
+            shutil.rmtree(backup_dir)
+        self.registry.delete(name)
+
+    def start_instance(self, name: str) -> None:
+        instance = self.registry.load(name)
+        unit_path = self.systemd.unit_path(instance.systemd_unit)
+        if not unit_path.exists():
+            unit_content = self.render_systemd_unit(instance)
+            self.systemd.write_unit(instance.systemd_unit, unit_content)
+        self.systemd.start(instance.systemd_unit)
+
+    def stop_instance(self, name: str) -> None:
+        instance = self.registry.load(name)
+        self.systemd.stop(instance.systemd_unit)
+
+    def restart_instance(self, name: str) -> None:
+        instance = self.registry.load(name)
+        self.systemd.restart(instance.systemd_unit)
+
+    def status_instance(self, name: str) -> str:
+        instance = self.registry.load(name)
+        return self.systemd.status(instance.systemd_unit)

--- a/mysqlm/logging_utils.py
+++ b/mysqlm/logging_utils.py
@@ -1,0 +1,54 @@
+"""Logging helpers for mysqlm."""
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+from rich.logging import RichHandler
+
+from . import constants
+
+_LOGGER_INITIALIZED = False
+
+
+def configure_logging(verbose: bool = False, log_path: Optional[Path] = None) -> logging.Logger:
+    """Configure root logger with console and rotating file handlers."""
+
+    global _LOGGER_INITIALIZED
+    logger = logging.getLogger()
+    if _LOGGER_INITIALIZED:
+        if verbose:
+            for handler in logger.handlers:
+                if isinstance(handler, RichHandler):
+                    handler.setLevel(logging.DEBUG)
+        return logger
+
+    logger.setLevel(logging.DEBUG)
+    logger.handlers.clear()
+
+    console_handler = RichHandler(rich_tracebacks=True, show_time=False, show_path=False)
+    console_handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+    logger.addHandler(console_handler)
+
+    log_path = log_path or (constants.DEFAULT_LOG_DIR / "mysqlm.log")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    file_handler = RotatingFileHandler(log_path, maxBytes=5_000_000, backupCount=5)
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    logger.addHandler(file_handler)
+
+    _LOGGER_INITIALIZED = True
+    logger.debug("Logging initialized. Log file: %s", log_path)
+    return logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return module logger after ensuring logging is configured."""
+
+    if not _LOGGER_INITIALIZED:
+        configure_logging()
+    return logging.getLogger(name)

--- a/mysqlm/models.py
+++ b/mysqlm/models.py
@@ -1,0 +1,79 @@
+"""Data models for mysqlm."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from . import constants
+
+
+@dataclass
+class InstanceConfig:
+    """Representation of a managed MySQL instance."""
+
+    name: str
+    port: int
+    socket: str
+    datadir: str
+    config_path: str
+    log_dir: str
+    error_log: str
+    slow_log: str
+    pid_file: str
+    runtime_dir: str
+    backup_dir: str
+    mysql_version: Optional[str]
+    created_at: str
+    last_modified: str
+    systemd_unit: str
+    root_password_path: str
+    root_password_set: bool = False
+
+    @property
+    def config_dir(self) -> str:
+        return str(Path(self.config_path).parent)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "port": self.port,
+            "socket": self.socket,
+            "datadir": self.datadir,
+            "config_path": self.config_path,
+            "log_dir": self.log_dir,
+            "error_log": self.error_log,
+            "slow_log": self.slow_log,
+            "pid_file": self.pid_file,
+            "runtime_dir": self.runtime_dir,
+            "backup_dir": self.backup_dir,
+            "mysql_version": self.mysql_version,
+            "created_at": self.created_at,
+            "last_modified": self.last_modified,
+            "systemd_unit": self.systemd_unit,
+            "root_password_path": self.root_password_path,
+            "root_password_set": self.root_password_set,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "InstanceConfig":
+        return cls(
+            name=str(data["name"]),
+            port=int(data["port"]),
+            socket=str(data["socket"]),
+            datadir=str(data["datadir"]),
+            config_path=str(data["config_path"]),
+            log_dir=str(data["log_dir"]),
+            error_log=str(data["error_log"]),
+            slow_log=str(data["slow_log"]),
+            pid_file=str(data["pid_file"]),
+            runtime_dir=str(data["runtime_dir"]),
+            backup_dir=str(data.get("backup_dir", constants.DEFAULT_BACKUP_ROOT)),
+            mysql_version=data.get("mysql_version"),
+            created_at=str(data.get("created_at", datetime.utcnow().isoformat())),
+            last_modified=str(data.get("last_modified", datetime.utcnow().isoformat())),
+            systemd_unit=str(data["systemd_unit"]),
+            root_password_path=str(data.get("root_password_path", "")),
+            root_password_set=bool(data.get("root_password_set", False)),
+        )

--- a/mysqlm/mysql_repository.py
+++ b/mysqlm/mysql_repository.py
@@ -1,0 +1,106 @@
+"""MySQL repository and package management."""
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass
+from typing import List
+
+from . import constants
+from .logging_utils import get_logger
+from .system import run_command
+from .utils import detect_package_manager
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass
+class PackageVersion:
+    version: str
+    release: str
+
+    @property
+    def full_version(self) -> str:
+        return f"{self.version}-{self.release}" if self.release else self.version
+
+
+class MySQLRepositoryManager:
+    """Manage the official Oracle MySQL yum repository."""
+
+    def __init__(self) -> None:
+        self.pkg_mgr = detect_package_manager()
+
+    def _package_cmd(self, *args: str) -> List[str]:
+        return [self.pkg_mgr, *args]
+
+    def check_mariadb_conflict(self) -> None:
+        result = run_command(["rpm", "-qa"], capture_output=True, check=False)
+        conflicts = [line for line in result.stdout.splitlines() if line.lower().startswith("mariadb")]
+        if conflicts:
+            raise RuntimeError(
+                "MariaDB packages detected ({}). Please remove them before installing MySQL.".format(
+                    ", ".join(conflicts)
+                )
+            )
+
+    def release_installed(self) -> bool:
+        result = run_command(["rpm", "-qa"], capture_output=True, check=False)
+        return any("mysql" in line and "community-release" in line for line in result.stdout.splitlines())
+
+    def install_release_package(self, minor: str) -> None:
+        url = constants.MYSQL_RELEASE_RPMS.get(minor)
+        if not url:
+            raise ValueError(f"Unsupported minor version {minor}")
+        run_command(["rpm", "-Uvh", url], sudo=True)
+
+    def enable_minor_repo(self, minor: str) -> None:
+        numeric = minor.replace(".", "")
+        repo = f"mysql{numeric}-community"
+        config_manager = shutil.which("yum-config-manager")
+        if not config_manager:
+            LOGGER.warning("yum-config-manager not found. Ensure the desired MySQL repo is enabled manually.")
+            return
+        disable_pattern = "mysql*-community"
+        run_command([config_manager, "--disable", disable_pattern], sudo=True, check=False)
+        run_command([config_manager, "--enable", repo], sudo=True)
+
+    def list_available_versions(self) -> List[PackageVersion]:
+        cmd = self._package_cmd("list", "--showduplicates", constants.MYSQL_PACKAGE)
+        result = run_command(cmd, capture_output=True)
+        versions: List[PackageVersion] = []
+        for line in result.stdout.splitlines():
+            if constants.MYSQL_PACKAGE in line and "@" not in line:
+                parts = line.split()
+                if len(parts) >= 2:
+                    version_release = parts[1]
+                    if "-" in version_release:
+                        version, release = version_release.split("-", 1)
+                    else:
+                        version, release = version_release, ""
+                    versions.append(PackageVersion(version=version, release=release))
+        if not versions:
+            LOGGER.warning("No MySQL versions discovered in repository output")
+        return versions
+
+    def resolve_latest_patch(self, minor: str) -> PackageVersion:
+        available = self.list_available_versions()
+        candidates = [ver for ver in available if ver.version.startswith(minor)]
+        if not candidates:
+            raise ValueError(f"No versions found for minor {minor}")
+        candidates.sort(key=lambda v: [int(x) for x in re.findall(r"\d+", v.version)], reverse=True)
+        return candidates[0]
+
+    def install_version(self, minor: str) -> PackageVersion:
+        self.check_mariadb_conflict()
+        if not self.release_installed():
+            self.install_release_package(minor)
+        self.enable_minor_repo(minor)
+        version = self.resolve_latest_patch(minor)
+        pkg_name = f"{constants.MYSQL_PACKAGE}-{version.version}"
+        run_command(self._package_cmd("install", "-y", pkg_name), sudo=True)
+        run_command(self._package_cmd("install", "-y", constants.MYSQL_CLIENT_PACKAGE), sudo=True)
+        return version
+
+    def upgrade_packages(self) -> None:
+        run_command(self._package_cmd("update", "-y", constants.MYSQL_PACKAGE), sudo=True)
+        run_command(self._package_cmd("update", "-y", constants.MYSQL_CLIENT_PACKAGE), sudo=True)

--- a/mysqlm/parameters.py
+++ b/mysqlm/parameters.py
@@ -1,0 +1,113 @@
+"""Configuration parameter management."""
+from __future__ import annotations
+
+import configparser
+import re
+from pathlib import Path
+from typing import Dict, Tuple
+
+from rich.table import Table
+
+from .logging_utils import get_logger
+from .models import InstanceConfig
+from .system import run_command
+from .utils import console
+
+LOGGER = get_logger(__name__)
+
+NUMERIC_PARAMS = {
+    "max_connections",
+    "innodb_buffer_pool_instances",
+    "innodb_io_capacity",
+    "thread_cache_size",
+}
+
+SIZE_PARAMS = {
+    "innodb_buffer_pool_size",
+    "innodb_log_file_size",
+    "tmp_table_size",
+    "innodb_log_buffer_size",
+}
+
+BOOLEAN_PARAMS = {
+    "slow_query_log",
+    "skip_name_resolve",
+    "log_bin",
+}
+
+SIZE_PATTERN = re.compile(r"^\d+[KMGTP]?$", re.IGNORECASE)
+
+
+def _read_config(instance: InstanceConfig) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser()
+    parser.optionxform = str  # preserve case
+    parser.read(instance.config_path)
+    if "mysqld" not in parser:
+        parser["mysqld"] = {}
+    return parser
+
+
+def validate_parameter(name: str, value: str) -> None:
+    if name in NUMERIC_PARAMS and not value.isdigit():
+        raise ValueError(f"Parameter {name} expects a numeric value")
+    if name in SIZE_PARAMS and not (value.isdigit() or SIZE_PATTERN.match(value)):
+        raise ValueError(
+            f"Parameter {name} expects size format such as 512M or 4G"
+        )
+    if name in BOOLEAN_PARAMS:
+        normalized = value.lower()
+        if normalized not in {"on", "off", "true", "false", "1", "0"}:
+            raise ValueError(f"Parameter {name} expects a boolean value (ON/OFF)")
+
+
+def set_parameter(instance: InstanceConfig, parameter: str, value: str) -> None:
+    parser = _read_config(instance)
+    validate_parameter(parameter, value)
+    parser["mysqld"][parameter] = value
+    with open(instance.config_path, "w") as fh:
+        parser.write(fh)
+    LOGGER.info("Parameter %s updated in %s", parameter, instance.config_path)
+
+
+def show_parameters(instance: InstanceConfig, live: bool = False) -> Tuple[Dict[str, str], Dict[str, str]]:
+    parser = _read_config(instance)
+    configured = dict(parser["mysqld"]) if parser.has_section("mysqld") else {}
+    live_values: Dict[str, str] = {}
+    if live and configured:
+        if not Path(instance.root_password_path).exists():
+            LOGGER.warning("Root password file %s not found; skipping live values", instance.root_password_path)
+        else:
+            password = Path(instance.root_password_path).read_text().strip()
+            if password:
+                params = "','".join(configured.keys())
+                query = f"SHOW VARIABLES WHERE Variable_name IN ('{params}')"
+                result = run_command(
+                    [
+                        "mysql",
+                        f"--socket={instance.socket}",
+                        "-uroot",
+                        f"-p{password}",
+                        "--batch",
+                        "--skip-column-names",
+                        "-e",
+                        query,
+                    ],
+                    sudo=True,
+                    mask_secrets=[password],
+                    check=False,
+                )
+                for line in result.stdout.splitlines():
+                    if "\t" in line:
+                        key, val = line.split("\t", 1)
+                        live_values[key] = val
+    return configured, live_values
+
+
+def display_parameters(instance: InstanceConfig, configured: Dict[str, str], live: Dict[str, str]) -> None:
+    table = Table(title=f"Parameters for {instance.name}")
+    table.add_column("Parameter", style="bold")
+    table.add_column("Configured Value")
+    table.add_column("Live Value", style="cyan")
+    for key, value in sorted(configured.items()):
+        table.add_row(key, value, live.get(key, ""))
+    console.print(table)

--- a/mysqlm/registry.py
+++ b/mysqlm/registry.py
@@ -1,0 +1,84 @@
+"""Instance registry and global configuration storage."""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+import yaml
+
+from . import constants
+from .logging_utils import get_logger
+from .models import InstanceConfig
+
+LOGGER = get_logger(__name__)
+
+
+class ConfigStore:
+    """Manage the global mysqlm configuration file."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = path or self._select_path()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.save({})
+
+    def _select_path(self) -> Path:
+        for path in constants.GLOBAL_CONFIG_PATHS:
+            parent = path.parent
+            if os.access(parent, os.W_OK) or not parent.exists():
+                return path
+        fallback = Path.home() / ".config" / "mysqlm" / "config.yaml"
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        return fallback
+
+    def load(self) -> dict:
+        if not self.path.exists():
+            return {}
+        return yaml.safe_load(self.path.read_text()) or {}
+
+    def save(self, data: dict) -> None:
+        self.path.write_text(yaml.safe_dump(data, sort_keys=False))
+        os.chmod(self.path, 0o640)
+
+
+class InstanceRegistry:
+    """YAML-based registry for MySQL instances."""
+
+    def __init__(self, directory: Optional[Path] = None) -> None:
+        self.directory = directory or constants.INSTANCE_REGISTRY_DIR
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, name: str) -> Path:
+        return self.directory / f"{name}.yaml"
+
+    def exists(self, name: str) -> bool:
+        return self._path(name).exists()
+
+    def load(self, name: str) -> InstanceConfig:
+        path = self._path(name)
+        if not path.exists():
+            raise FileNotFoundError(f"Instance '{name}' is not registered")
+        data = yaml.safe_load(path.read_text()) or {}
+        return InstanceConfig.from_dict(data)
+
+    def save(self, instance: InstanceConfig) -> None:
+        path = self._path(instance.name)
+        instance.last_modified = datetime.utcnow().isoformat()
+        data = instance.to_dict()
+        path.write_text(yaml.safe_dump(data, sort_keys=False))
+        os.chmod(path, 0o640)
+
+    def delete(self, name: str) -> None:
+        path = self._path(name)
+        if path.exists():
+            path.unlink()
+
+    def list_instances(self) -> Iterable[InstanceConfig]:
+        for path in sorted(self.directory.glob("*.yaml")):
+            try:
+                data = yaml.safe_load(path.read_text()) or {}
+                yield InstanceConfig.from_dict(data)
+            except Exception as exc:  # pragma: no cover
+                LOGGER.error("Failed to parse %s: %s", path, exc)

--- a/mysqlm/system.py
+++ b/mysqlm/system.py
@@ -1,0 +1,136 @@
+"""System utilities for executing commands and interacting with the OS."""
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+from .logging_utils import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class CommandError(RuntimeError):
+    """Raised when a system command fails."""
+
+    def __init__(self, command: Sequence[str], returncode: int, stdout: str, stderr: str):
+        self.command = command
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:  # pragma: no cover - formatting method
+        return (
+            f"Command '{' '.join(self.command)}' failed with exit code {self.returncode}."
+            f" Stdout: {self.stdout.strip()} Stderr: {self.stderr.strip()}"
+        )
+
+
+def _mask(text: str, mask_secrets: Optional[Iterable[str]]) -> str:
+    if not mask_secrets:
+        return text
+    masked = text
+    for secret in mask_secrets:
+        if secret:
+            masked = masked.replace(secret, "******")
+    return masked
+
+
+def run_command(
+    command: Sequence[str],
+    *,
+    sudo: bool = False,
+    check: bool = True,
+    capture_output: bool = True,
+    env: Optional[dict] = None,
+    cwd: Optional[Path] = None,
+    timeout: Optional[int] = None,
+    mask_secrets: Optional[Iterable[str]] = None,
+    stdout_path: Optional[Path] = None,
+    stderr_path: Optional[Path] = None,
+    stdin_path: Optional[Path] = None,
+) -> subprocess.CompletedProcess:
+    """Execute a system command, raising :class:`CommandError` when it fails."""
+
+    cmd = list(command)
+    if sudo and os.geteuid() != 0:
+        cmd = ["sudo"] + cmd
+    display_cmd = _mask(" ".join(cmd), mask_secrets)
+    LOGGER.debug("Executing command: %s", display_cmd)
+
+    stdout_handle = None
+    stderr_handle = None
+    stdin_handle = None
+    stdout = subprocess.PIPE if capture_output and not stdout_path else None
+    stderr = subprocess.PIPE if capture_output and not stderr_path else None
+    stdin = None
+    if stdout_path:
+        stdout_handle = open(stdout_path, "wb")
+        stdout = stdout_handle
+    if stderr_path:
+        stderr_handle = open(stderr_path, "wb")
+        stderr = stderr_handle
+    if stdin_path:
+        stdin_handle = open(stdin_path, "rb")
+        stdin = stdin_handle
+
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            stdout=stdout,
+            stderr=stderr,
+            stdin=stdin,
+            text=not stdout_path,
+            env=env,
+            cwd=str(cwd) if cwd else None,
+            timeout=timeout,
+        )
+    finally:
+        if stdout_handle:
+            stdout_handle.close()
+        if stderr_handle:
+            stderr_handle.close()
+        if stdin_handle:
+            stdin_handle.close()
+
+    if check and result.returncode != 0:
+        stdout_text = result.stdout if capture_output and not stdout_path else ""
+        stderr_text = result.stderr if capture_output and not stderr_path else ""
+        raise CommandError(cmd, result.returncode, stdout_text or "", stderr_text or "")
+
+    LOGGER.debug(
+        "Command finished rc=%s stdout=%s stderr=%s",
+        result.returncode,
+        _mask(result.stdout.strip(), mask_secrets) if getattr(result, "stdout", None) else "",
+        _mask(result.stderr.strip(), mask_secrets) if getattr(result, "stderr", None) else "",
+    )
+    return result
+
+
+def wait_for_socket(path: Path, timeout: int = 60, expect_exists: bool = True) -> None:
+    """Wait for a UNIX socket file to appear or disappear."""
+
+    LOGGER.debug("Waiting for socket %s (expect_exists=%s)", path, expect_exists)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        exists = path.exists()
+        if exists and expect_exists:
+            return
+        if not exists and not expect_exists:
+            return
+        time.sleep(1)
+    state = "appear" if expect_exists else "disappear"
+    raise TimeoutError(f"Socket {path} did not {state} within {timeout} seconds")
+
+
+def is_root() -> bool:
+    return os.geteuid() == 0
+
+
+def ensure_root() -> None:
+    if not is_root():
+        raise PermissionError("This action requires root privileges. Please re-run with sudo.")

--- a/mysqlm/systemd.py
+++ b/mysqlm/systemd.py
@@ -1,0 +1,55 @@
+"""Systemd unit management for mysqlm."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .logging_utils import get_logger
+from .system import run_command
+
+LOGGER = get_logger(__name__)
+
+
+class SystemdManager:
+    """Helper for managing systemd service units."""
+
+    def __init__(self, unit_dir: Path = Path("/etc/systemd/system")) -> None:
+        self.unit_dir = unit_dir
+
+    def unit_path(self, unit_name: str) -> Path:
+        return self.unit_dir / unit_name
+
+    def write_unit(self, unit_name: str, content: str, reload: bool = True) -> Path:
+        path = self.unit_path(unit_name)
+        path.write_text(content)
+        path.chmod(0o644)
+        if reload:
+            self.daemon_reload()
+        return path
+
+    def daemon_reload(self) -> None:
+        run_command(["systemctl", "daemon-reload"], sudo=True)
+
+    def enable(self, unit_name: str) -> None:
+        run_command(["systemctl", "enable", unit_name], sudo=True)
+
+    def disable(self, unit_name: str) -> None:
+        run_command(["systemctl", "disable", unit_name], sudo=True, check=False)
+
+    def start(self, unit_name: str) -> None:
+        run_command(["systemctl", "start", unit_name], sudo=True)
+
+    def stop(self, unit_name: str) -> None:
+        run_command(["systemctl", "stop", unit_name], sudo=True, check=False)
+
+    def restart(self, unit_name: str) -> None:
+        run_command(["systemctl", "restart", unit_name], sudo=True)
+
+    def status(self, unit_name: str) -> str:
+        result = run_command(
+            ["systemctl", "status", unit_name, "--no-pager"],
+            sudo=True,
+            capture_output=True,
+            check=False,
+        )
+        return result.stdout

--- a/mysqlm/upgrade.py
+++ b/mysqlm/upgrade.py
@@ -1,0 +1,81 @@
+"""Upgrade workflows for MySQL instances."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from .backups import perform_backup
+from .logging_utils import get_logger
+from .models import InstanceConfig
+from .mysql_repository import MySQLRepositoryManager
+from .registry import InstanceRegistry
+from .system import run_command, wait_for_socket
+from .utils import human_readable_size
+
+LOGGER = get_logger(__name__)
+
+
+class UpgradeManager:
+    """Handle in-place upgrades of MySQL instances."""
+
+    def __init__(self, registry: InstanceRegistry) -> None:
+        self.registry = registry
+        self.repo = MySQLRepositoryManager()
+
+    def _check_disk_space(self, path: Path) -> None:
+        usage = shutil.disk_usage(path)
+        LOGGER.info(
+            "Disk space for %s: total=%s used=%s free=%s",
+            path,
+            human_readable_size(usage.total),
+            human_readable_size(usage.used),
+            human_readable_size(usage.free),
+        )
+        if usage.free < 5 * 1024 * 1024 * 1024:  # 5 GiB
+            LOGGER.warning("Free space below 5 GiB. Ensure there is enough space for upgrade")
+
+    def upgrade_instance(
+        self,
+        instance_name: str,
+        target_minor: str,
+        *,
+        take_backup: bool = True,
+        assume_yes: bool = False,
+    ) -> InstanceConfig:
+        instance = self.registry.load(instance_name)
+        self._check_disk_space(Path(instance.datadir))
+        if take_backup:
+            perform_backup(instance)
+        # stop service
+        from .instance_manager import InstanceManager  # avoid circular import
+
+        manager = InstanceManager(self.registry)
+        manager.stop_instance(instance_name)
+
+        version = self.repo.install_version(target_minor)
+        LOGGER.info("Packages upgraded to %s", version.version)
+
+        manager.start_instance(instance_name)
+        wait_for_socket(Path(instance.socket), timeout=120)
+
+        password = Path(instance.root_password_path).read_text().strip() if instance.root_password_path else ""
+        if not password:
+            LOGGER.warning("Root password unavailable; skipping mysql_upgrade. Run manually.")
+        else:
+            run_command(
+                [
+                    "mysql_upgrade",
+                    f"--socket={instance.socket}",
+                    "-uroot",
+                    f"-p{password}",
+                ],
+                sudo=True,
+                mask_secrets=[password],
+            )
+            LOGGER.info("mysql_upgrade completed")
+
+        manager.restart_instance(instance_name)
+        instance.mysql_version = version.version
+        self.registry.save(instance)
+        return instance

--- a/mysqlm/utils.py
+++ b/mysqlm/utils.py
@@ -1,0 +1,65 @@
+"""Utility helpers for mysqlm."""
+from __future__ import annotations
+
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+import questionary
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def detect_package_manager() -> str:
+    """Return the preferred package manager (dnf or yum)."""
+
+    for candidate in ("dnf", "yum"):
+        if shutil.which(candidate):
+            return candidate
+    raise RuntimeError("Neither yum nor dnf is available on this system")
+
+
+def confirm(question: str, default: bool = True, assume_yes: bool = False) -> bool:
+    if assume_yes:
+        return True
+    if not sys.stdin.isatty():
+        return default
+    return bool(questionary.confirm(question, default=default).ask())
+
+
+def choose(question: str, choices: Iterable[str]) -> Optional[str]:
+    if not sys.stdin.isatty():
+        return next(iter(choices), None)
+    return questionary.select(question, choices=list(choices)).ask()
+
+
+def info_table(title: str, rows: Iterable[tuple[str, str]]) -> None:
+    table = Table(title=title, show_header=False)
+    table.add_column("Property", style="bold")
+    table.add_column("Value")
+    for key, value in rows:
+        table.add_row(key, value)
+    console.print(table)
+
+
+def timestamp() -> str:
+    return datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+
+
+def human_readable_size(num_bytes: int) -> str:
+    step_to_greater_unit = 1024.0
+    num = float(num_bytes)
+    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
+        if num < step_to_greater_unit:
+            return f"{num:3.1f} {unit}"
+        num /= step_to_greater_unit
+    return f"{num:.1f} PiB"
+
+
+def ensure_directory(path: Path, mode: int = 0o750) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    path.chmod(mode)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "mysql-manager"
+version = "0.1.0"
+description = "Interactive CLI for managing Oracle MySQL Community Server on Amazon Linux 2"
+authors = ["DevOps Engineer <devops@example.com>"]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "typer[all]",
+    "rich",
+    "PyYAML",
+    "questionary"
+]
+
+[project.scripts]
+mysqlm = "mysqlm.cli:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- introduce a Typer-based `mysqlm` CLI that installs MySQL, provisions instances, manages parameters, runs backups/restores, and drives upgrades via systemd on Amazon Linux 2
- add supporting modules for repository enablement, instance registry, logging, system execution wrappers, parameter validation, and backup/upgrade helpers
- document prerequisites, directory layout, usage scenarios, and troubleshooting steps in a comprehensive README and declare project dependencies in `pyproject.toml`

## Testing
- python -m compileall mysqlm
- pip install -e . *(fails: outbound network to PyPI blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3043e1bd4832f811c391f6785bb09