### PR TITLE
Use object-style author metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mysql-manager"
 version = "0.1.0"
 description = "Interactive CLI for managing Oracle MySQL Community Server on Amazon Linux 2"
-authors = ["DevOps Engineer <devops@example.com>"]
+authors = [{ name = "DevOps Engineer", email = "devops@example.com" }]
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
## Summary
- update the project metadata to use an object-style authors declaration

## Testing
- pip install -e . *(fails: network proxy prevented downloading setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_68d45b873a48832fa670ffe01d398c6b