### PR TITLE
Handle registry fallbacks when system paths unwritable

### DIFF
--- a/mysqlm/registry.py
+++ b/mysqlm/registry.py
@@ -19,19 +19,41 @@ class ConfigStore:
     """Manage the global mysqlm configuration file."""
 
     def __init__(self, path: Optional[Path] = None) -> None:
-        self.path = path or self._select_path()
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        selected_path = path or self._select_path()
+        self.path = self._ensure_path(selected_path, explicit=path is not None)
         if not self.path.exists():
             self.save({})
 
     def _select_path(self) -> Path:
         for path in constants.GLOBAL_CONFIG_PATHS:
             parent = path.parent
-            if os.access(parent, os.W_OK) or not parent.exists():
-                return path
-        fallback = Path.home() / ".config" / "mysqlm" / "config.yaml"
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        return fallback
+            if parent.exists():
+                if os.access(parent, os.W_OK):
+                    return path
+            else:
+                ancestor = parent.parent
+                if ancestor != parent and ancestor.exists() and os.access(ancestor, os.W_OK):
+                    return path
+        return self._user_config_path()
+
+    def _ensure_path(self, candidate: Path, *, explicit: bool) -> Path:
+        try:
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            return candidate
+        except PermissionError:
+            if explicit:
+                raise
+            fallback = self._user_config_path()
+            fallback.parent.mkdir(parents=True, exist_ok=True)
+            return fallback
+
+    def _user_config_path(self) -> Path:
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+        if xdg_config_home:
+            base = Path(xdg_config_home)
+        else:
+            base = Path.home() / ".config"
+        return base / "mysqlm" / "config.yaml"
 
     def load(self) -> dict:
         if not self.path.exists():
@@ -47,8 +69,8 @@ class InstanceRegistry:
     """YAML-based registry for MySQL instances."""
 
     def __init__(self, directory: Optional[Path] = None) -> None:
-        self.directory = directory or constants.INSTANCE_REGISTRY_DIR
-        self.directory.mkdir(parents=True, exist_ok=True)
+        selected_directory = directory or constants.INSTANCE_REGISTRY_DIR
+        self.directory = self._ensure_directory(selected_directory, explicit=directory is not None)
 
     def _path(self, name: str) -> Path:
         return self.directory / f"{name}.yaml"
@@ -82,3 +104,22 @@ class InstanceRegistry:
                 yield InstanceConfig.from_dict(data)
             except Exception as exc:  # pragma: no cover
                 LOGGER.error("Failed to parse %s: %s", path, exc)
+
+    def _ensure_directory(self, directory: Path, *, explicit: bool) -> Path:
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+            return directory
+        except PermissionError:
+            if explicit:
+                raise
+            fallback = self._user_registry_dir()
+            fallback.mkdir(parents=True, exist_ok=True)
+            return fallback
+
+    def _user_registry_dir(self) -> Path:
+        xdg_state_home = os.environ.get("XDG_STATE_HOME")
+        if xdg_state_home:
+            base = Path(xdg_state_home)
+        else:
+            base = Path.home() / ".local" / "state"
+        return base / "mysqlm" / "instances"

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,72 @@
+"""Tests for mysqlm.logging_utils."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Iterable
+from unittest import TestCase
+from unittest.mock import patch
+
+from logging.handlers import RotatingFileHandler
+
+from mysqlm import constants, logging_utils
+
+
+def _reset_logging_state() -> None:
+    """Reset global logging state for tests."""
+
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        handler.close()
+        root_logger.removeHandler(handler)
+    logging_utils._LOGGER_INITIALIZED = False
+
+
+class ConfigureLoggingTests(TestCase):
+    def setUp(self) -> None:  # noqa: D401 - standard unittest hook
+        _reset_logging_state()
+        self.addCleanup(_reset_logging_state)
+
+    def _get_file_handlers(self, logger: logging.Logger) -> Iterable[RotatingFileHandler]:
+        return [
+            handler
+            for handler in logger.handlers
+            if isinstance(handler, RotatingFileHandler)
+        ]
+
+    def test_configure_logging_falls_back_when_default_unwritable(self) -> None:
+        """configure_logging should use a user-writable fallback on PermissionError."""
+
+        with TemporaryDirectory() as tmpdir:
+            fallback_dir = Path(tmpdir) / "mysqlm"
+            original_mkdir = Path.mkdir
+
+            def fake_mkdir(path_obj: Path, *args, **kwargs):
+                if path_obj == constants.DEFAULT_LOG_DIR:
+                    raise PermissionError("cannot create default log dir")
+                return original_mkdir(path_obj, *args, **kwargs)
+
+            with patch.dict(os.environ, {"XDG_STATE_HOME": tmpdir}, clear=False):
+                with patch("pathlib.Path.mkdir", autospec=True) as mocked_mkdir:
+                    mocked_mkdir.side_effect = fake_mkdir
+                    logger = logging_utils.configure_logging()
+
+            self.assertTrue(fallback_dir.exists(), "Fallback log directory should be created")
+            file_handlers = list(self._get_file_handlers(logger))
+            self.assertEqual(1, len(file_handlers))
+            expected_path = fallback_dir / "mysqlm.log"
+            self.assertEqual(str(expected_path), file_handlers[0].baseFilename)
+
+    def test_configure_logging_honors_explicit_log_path(self) -> None:
+        """Providing log_path should bypass fallback logic."""
+
+        with TemporaryDirectory() as tmpdir:
+            explicit_path = Path(tmpdir) / "custom.log"
+            logger = logging_utils.configure_logging(log_path=explicit_path)
+
+        file_handlers = list(self._get_file_handlers(logger))
+        self.assertEqual(1, len(file_handlers))
+        self.assertEqual(str(explicit_path), file_handlers[0].baseFilename)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,59 @@
+"""Tests for mysqlm.registry fallbacks."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from mysqlm import constants
+from mysqlm.registry import ConfigStore, InstanceRegistry
+
+
+class RegistryFallbackTests(TestCase):
+    def test_config_store_falls_back_when_system_path_unwritable(self) -> None:
+        """ConfigStore should fall back to a user-writable config file."""
+
+        with TemporaryDirectory() as tmpdir:
+            xdg_config_home = Path(tmpdir) / "config"
+            fallback_path = xdg_config_home / "mysqlm" / "config.yaml"
+            original_mkdir = Path.mkdir
+
+            def fake_mkdir(path_obj: Path, *args, **kwargs):  # type: ignore[override]
+                if path_obj == constants.GLOBAL_CONFIG_PATHS[0].parent:
+                    raise PermissionError("cannot create system config directory")
+                return original_mkdir(path_obj, *args, **kwargs)
+
+            with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(xdg_config_home)}, clear=False):
+                with patch.object(constants, "GLOBAL_CONFIG_PATHS", [Path("/etc/mysqlm/config.yaml")]):
+                    with patch("pathlib.Path.mkdir", autospec=True) as mocked_mkdir:
+                        mocked_mkdir.side_effect = fake_mkdir
+                        store = ConfigStore()
+
+            self.assertEqual(fallback_path, store.path)
+            self.assertTrue(store.path.exists(), "Fallback config file should be created")
+
+    def test_instance_registry_falls_back_when_system_dir_unwritable(self) -> None:
+        """InstanceRegistry should fall back to a user-writable directory."""
+
+        with TemporaryDirectory() as tmpdir:
+            xdg_state_home = Path(tmpdir) / "state"
+            fallback_dir = xdg_state_home / "mysqlm" / "instances"
+            original_mkdir = Path.mkdir
+
+            def fake_mkdir(path_obj: Path, *args, **kwargs):  # type: ignore[override]
+                if path_obj == constants.INSTANCE_REGISTRY_DIR:
+                    raise PermissionError("cannot create system registry directory")
+                return original_mkdir(path_obj, *args, **kwargs)
+
+            with patch.dict(os.environ, {"XDG_STATE_HOME": str(xdg_state_home)}, clear=False):
+                with patch.object(constants, "INSTANCE_REGISTRY_DIR", Path("/etc/mysqlm/instances")):
+                    with patch("pathlib.Path.mkdir", autospec=True) as mocked_mkdir:
+                        mocked_mkdir.side_effect = fake_mkdir
+                        registry = InstanceRegistry()
+
+            self.assertEqual(fallback_dir, registry.directory)
+            self.assertTrue(registry.directory.exists(), "Fallback registry directory should be created")
+


### PR DESCRIPTION
## Summary
- add fallback handling in ConfigStore and InstanceRegistry to use user-writable locations when system paths are not accessible
- respect explicitly supplied paths while deriving XDG-compliant defaults for fallback locations
- introduce unit tests covering the new fallback behavior for both the global config store and instance registry

## Testing
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68d470cefde4832fa64b020854af4d0e